### PR TITLE
markupsafe depends upon setuptools for building.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,12 @@ source:
 
 build:
   number: 0
-  script: python setup.py install
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
     - python
+    - setuptools
   run:
     - python
 


### PR DESCRIPTION
I was unable to build locally because of this. We should try to disable automatic setuptools/pip availability in conda-forge (ping @jakirkham).
